### PR TITLE
allow esnext module import

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "Stefan Nieke (https://niekes.com)",
   "license": "BSD-3-Clause",
   "main": "build/d3-3d.js",
+  "module": "index.js",
   "jsnext:main": "index",
   "homepage": "https://github.com/niekes/d3-3d",
   "repository": {


### PR DESCRIPTION
Hi @Niekes,

I'd like to use your library as an es module, alongside other D3 modules in my application, and I need the `module` field in package.json to be set properly.
This field is currently a proposal, but it's already implemented in other D3 modules: https://github.com/d3/d3-shape/blob/master/package.json#L22

The proposal is here for more details: https://github.com/rollup/rollup/wiki/pkg.module

Thanks for reviewing 