### PR TITLE
fix: rotate projected coordinates for `points3D`

### DIFF
--- a/src/shapes/points.ts
+++ b/src/shapes/points.ts
@@ -30,7 +30,7 @@ class Points3DRenderer<Datum = Point3D>
                 rotateCenter: this.rotationCenter()
             });
 
-            const projected = orthographic(startPoint, {
+            const projected = orthographic(rotated, {
                 scale: this.scale(),
                 origin: this.origin()
             });

--- a/tests/points.test.ts
+++ b/tests/points.test.ts
@@ -91,4 +91,11 @@ describe('points3D', () => {
 
         expect(points.data(data)[0].projected).toEqual({ x: 100, y: 100 });
     });
+
+    test('rotates point 0|0|1 along y axis by 90° and projects onto screen', () => {
+        const data = [{ x: 0, y: 0, z: 1 }];
+        const points = points3D().rotateY(Math.PI / 2);
+
+        expect(points.data(data)[0].projected).toEqual({ x: 1, y: 0 });
+    });
 });


### PR DESCRIPTION
Use the rotated 3D coordinates to calculate the projected 2D coordinates for `points3D`. Add a test to check that a rotation is applied to the projection.

Fixes #41