### PR TITLE
fix: add `d3-3d.es.js` to published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     },
     "files": [
         "build/d3-3d.js",
+        "build/d3-3d.es.js",
         "build/index.d.ts",
         "build/**/*.d.ts"
     ],


### PR DESCRIPTION
Add `build/d3-3d.es.js` to `files` in `package.json` so that it is included in the bundle published to npm.

Fixes #36